### PR TITLE
NEW : Conf to use price_min as price_ht

### DIFF
--- a/admin/getcustomerprice.php
+++ b/admin/getcustomerprice.php
@@ -200,6 +200,16 @@ print '<td align="center" width="300">';
 print ajax_constantonoff('GETCUSTOMERPRICE_PRICE_BY_QTY');
 print '</td></tr>';
 
+// Price min
+$var=!$var;
+print '<tr '.$bc[$var].'>';
+print '<td>'.$form->textwithpicto($langs->trans("UsePriceMinAsDiscountPrice"), $langs->trans('UsePriceMinAsDiscountPrice_tooltip')).'</td>';
+print '<td align="center" width="20">&nbsp;</td>';
+
+print '<td align="center" width="300">';
+print ajax_constantonoff('GETCUSTOMERPRICE_ADAPT_PRICE_FROM_SOURCE');
+print '</td></tr>';
+
 print '</table>';
 
 print '<br><br>';

--- a/langs/fr_FR/getcustomerprice.lang
+++ b/langs/fr_FR/getcustomerprice.lang
@@ -23,6 +23,9 @@ Multicompany=Options du module multi sociétés
 ActivateSharing=Activer le partage des prix client entre entités (pensez à configurer le partage ci-dessous)
 ShareWith=Partager avec
 MulticompanyConfiguration=Configuration des partages entre entités
+UsePriceMinAsDiscountPrice=Utiliser le prix minimum d'un produit comme prix de vente HT
+UsePriceMinAsDiscountPrice_tooltip=Uniquement si le prix trouvé est inférieur au prix minimum du produit en question
+PriceFoundButBelowPriceMin=Le prix client récupéré est de %s mais celui est inférieur au prix minimum du produit (%s)
 
 # MSG
 CustomerPriceFromPropal=Prix client récupéré de la proposition %s


### PR DESCRIPTION
Si la conf est activée, ça vérifie si le prix récupéré n'est pas inférieur au prix minimum du produit
S'il l'est, ça recalcule la remise pour que le prix soit égal au prix minimum

ça utilise le droit avancé des produits "Outrepasser le prix de vente minimum d'un produit"